### PR TITLE
Fix for some keyboards not working properly and minor code improvements

### DIFF
--- a/Sources/autokbisw/IOKeyEventMonitor.swift
+++ b/Sources/autokbisw/IOKeyEventMonitor.swift
@@ -22,8 +22,9 @@ internal final class IOKeyEventMonitor {
     private let hidManager: IOHIDManager
     fileprivate let MAPPINGS_DEFAULTS_KEY = "keyboardISMapping"
     fileprivate let notificationCenter: CFNotificationCenter
-    fileprivate var lastActiveKeyboard: String = ""
-    fileprivate var kb2is: [String: TISInputSource] = .init()
+    fileprivate var lastActiveKeyboard: String? = nil
+    fileprivate var kb2is: [String: KeyboardState] = .init()
+    fileprivate var lang2inputSource: [String: TISInputSource] = .init()
     fileprivate var defaults: UserDefaults = .standard
     fileprivate var useLocation: Bool
     fileprivate var verbosity: Int
@@ -106,79 +107,139 @@ internal final class IOKeyEventMonitor {
     }
 }
 
-extension IOKeyEventMonitor {
-    func restoreInputSource(keyboard: String) {
-        if let targetIs = kb2is[keyboard] {
-            if verbosity >= DEBUG {
-                print("set input source to \(targetIs) for keyboard \(keyboard)")
-            }
-            TISSelectInputSource(targetIs)
+fileprivate func unmanagedStringToString(_ p: UnsafeMutableRawPointer?) -> String? {
+    if let cfValue = p {
+        let value = Unmanaged.fromOpaque(cfValue).takeUnretainedValue() as CFString
+        if CFGetTypeID(value) == CFStringGetTypeID() {
+            return value as String
         } else {
-            storeInputSource(keyboard: keyboard)
+            return nil
         }
+    } else {
+        return nil
     }
+}
 
-    func storeInputSource(keyboard: String) {
-        let currentSource: TISInputSource = TISCopyCurrentKeyboardInputSource().takeUnretainedValue()
-        kb2is[keyboard] = currentSource
-        saveMappings()
-    }
-
-    func onInputSourceChanged() {
-        storeInputSource(keyboard: lastActiveKeyboard)
-    }
-
-    func onKeyboardEvent(keyboard: String) {
-        guard keyboard != "CONFORMS_TO_MOUSE" else { return }
-        guard lastActiveKeyboard != keyboard else { return }
-
-        restoreInputSource(keyboard: keyboard)
-        lastActiveKeyboard = keyboard
-    }
-
+extension IOKeyEventMonitor {
+    /**
+     Init/deinit functions
+     */
+    
     func loadMappings() {
         let selectableIsProperties = [
             kTISPropertyInputSourceIsEnableCapable: true,
             kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource ?? "" as CFString,
         ] as CFDictionary
         let inputSources = TISCreateInputSourceList(selectableIsProperties, false).takeUnretainedValue() as! [TISInputSource]
-
-        let inputSourcesById = inputSources.reduce([String: TISInputSource]()) {
+        
+        if verbosity >= DEBUG {
+            print("Loading mappings\n")
+        }
+        self.lang2inputSource = inputSources.reduce([String: TISInputSource]()) {
             dict, inputSource -> [String: TISInputSource] in
                 var dict = dict
                 if let id = unmanagedStringToString(TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID)) {
                     dict[id] = inputSource
+                    if verbosity >= DEBUG {
+                        print("\t\(id):\t\(inputSource)")
+                    }
                 }
                 return dict
         }
+        
+        if verbosity >= DEBUG {
+            print("\nPersisted configs\n")
+        }
 
-        if let mappings = defaults.dictionary(forKey: MAPPINGS_DEFAULTS_KEY) {
-            for (keyboardId, inputSourceId) in mappings {
-                kb2is[keyboardId] = inputSourcesById[String(describing: inputSourceId)]
+        self.kb2is = Dictionary()
+        guard let stored = defaults.dictionary(forKey: MAPPINGS_DEFAULTS_KEY) else {
+            return
+        }
+        for (key, val) in stored {
+            guard let data = val as? Data else {
+                continue
+            }
+            let decoded = try? PropertyListDecoder().decode(KeyboardState.self, from: data)
+            guard let retval = decoded else {
+                continue
+            }
+            self.kb2is[key] = retval
+            if verbosity >= DEBUG {
+                print("\t\(key):\t\(retval)")
             }
         }
+        
+        if verbosity >= DEBUG {
+            print("")
+        }
     }
-
+    
+    /**
+     Store functions
+     */
+    
     func saveMappings() {
-        let mappings = kb2is.mapValues(is2Id)
-        defaults.set(mappings, forKey: MAPPINGS_DEFAULTS_KEY)
+        let data = kb2is.mapValues{ val in
+            return try? PropertyListEncoder().encode(val)
+        }
+        defaults.set(data, forKey: MAPPINGS_DEFAULTS_KEY)
+    }
+    
+    func getKbdStateForSource() -> KeyboardState {
+        let currentSource: TISInputSource = TISCopyCurrentKeyboardInputSource().takeUnretainedValue()
+        let lang = unmanagedStringToString(TISGetInputSourceProperty(currentSource, kTISPropertyInputSourceID))!
+        return KeyboardState(lang: lang)
     }
 
-    private func is2Id(_ inputSource: TISInputSource) -> String? {
-        return unmanagedStringToString(TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID))!
+    func storeInputSource(keyboard: String) {
+        let kbstate = getKbdStateForSource()
+        kb2is[keyboard] = kbstate
+        
+        if verbosity >= DEBUG {
+            print("STORing values for keyboard \(keyboard):\n\t\(kbstate)")
+        }
+        saveMappings()
     }
-
-    func unmanagedStringToString(_ p: UnsafeMutableRawPointer?) -> String? {
-        if let cfValue = p {
-            let value = Unmanaged.fromOpaque(cfValue).takeUnretainedValue() as CFString
-            if CFGetTypeID(value) == CFStringGetTypeID() {
-                return value as String
-            } else {
-                return nil
+    
+    /**
+     Apply functions
+     */
+    func restoreInputSource(keyboard: String) {
+        if let targetIs = kb2is[keyboard] {
+            if verbosity >= DEBUG {
+                print("SETting values for keyboard \(keyboard):\n\t\(targetIs)")
+            }
+            if let lang = self.lang2inputSource[String(describing: targetIs.lang)] {
+                TISSelectInputSource(lang)
             }
         } else {
-            return nil
+            storeInputSource(keyboard: keyboard)
         }
+    }
+    
+    /**
+     Entrypoints functions
+     */
+
+    func onInputSourceChanged() {
+        if let lastActiveKeyboard = lastActiveKeyboard {
+            storeInputSource(keyboard: lastActiveKeyboard)
+        }
+    }
+
+    func onKeyboardEvent(keyboard: String) {
+        guard keyboard != "CONFORMS_TO_MOUSE" else { return }
+        if lastActiveKeyboard == nil {
+            // initialization, avoid overriding current state of things,
+            // supposing the system config should take priority over the stored one
+            lastActiveKeyboard = keyboard
+            return
+        }
+        guard lastActiveKeyboard != keyboard else { return }
+
+        // It's not a mouse nor the previous keyboard, so let's try restoring keyboard settings
+        restoreInputSource(keyboard: keyboard)
+        lastActiveKeyboard = keyboard
     }
 }
 

--- a/Sources/autokbisw/IOKeyEventMonitor.swift
+++ b/Sources/autokbisw/IOKeyEventMonitor.swift
@@ -229,17 +229,23 @@ extension IOKeyEventMonitor {
 
     func onKeyboardEvent(keyboard: String) {
         guard keyboard != "CONFORMS_TO_MOUSE" else { return }
-        if lastActiveKeyboard == nil {
+        guard let lastActiveKeyboard=lastActiveKeyboard else {
             // initialization, avoid overriding current state of things,
             // supposing the system config should take priority over the stored one
             lastActiveKeyboard = keyboard
+            if verbosity >= TRACE {
+                print("init: set active keyboard since startup to \(keyboard)")
+            }
             return
         }
         guard lastActiveKeyboard != keyboard else { return }
+        if verbosity >= TRACE {
+            print("change: keyboard changed from \(lastActiveKeyboard) to \(keyboard)")
+        }
 
         // It's not a mouse nor the previous keyboard, so let's try restoring keyboard settings
         restoreInputSource(keyboard: keyboard)
-        lastActiveKeyboard = keyboard
+        self.lastActiveKeyboard = keyboard
     }
 }
 

--- a/Sources/autokbisw/KeyboardState.swift
+++ b/Sources/autokbisw/KeyboardState.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paolo Polidori on 07/10/22.
+//
+
+import Foundation
+
+struct KeyboardState : Codable, CustomStringConvertible {
+    var lang: String
+    
+    init(lang: String) {
+        self.lang = lang
+    }
+    
+    public var description: String { return "\(lang)" }
+}


### PR DESCRIPTION
# Reasons for this PR

- There was a bug preventing events from particular keyboards from being stored. In the screenshot, an example of what was happening with my Keychron Q3.
![](https://user-images.githubusercontent.com/4489025/229124014-f47078de-b7bf-473f-88e3-b4acad526f50.png)
- Comments within the code and logs
- Added a lock to prevent race condition when typing with a different keyboard and changing language in the meantime (despite this might only verifyby running this program twice)
- Storing a Codable instead of a bare string, to support extensibility