### PR TITLE
Check if device is keyboard (instead of not mouse)

### DIFF
--- a/Sources/autokbisw/IOKeyEventMonitor.swift
+++ b/Sources/autokbisw/IOKeyEventMonitor.swift
@@ -74,7 +74,7 @@ internal final class IOKeyEventMonitor {
             let selfPtr = Unmanaged<IOKeyEventMonitor>.fromOpaque(context!).takeUnretainedValue()
             let senderDevice = Unmanaged<IOHIDDevice>.fromOpaque(sender!).takeUnretainedValue()
 
-            let conformsToMouse = IOHIDDeviceConformsTo(senderDevice, UInt32(kHIDPage_GenericDesktop), UInt32(kHIDUsage_GD_Mouse))
+            let conformsToKbd = IOHIDDeviceConformsTo(senderDevice, UInt32(kHIDPage_GenericDesktop), UInt32(kHIDUsage_GD_Keyboard))
 
             let vendorId = IOHIDDeviceGetProperty(senderDevice, kIOHIDVendorIDKey as CFString) ??? "unknown"
             let productId = IOHIDDeviceGetProperty(senderDevice, kIOHIDProductIDKey as CFString) ??? "unknown"
@@ -92,9 +92,9 @@ internal final class IOKeyEventMonitor {
                 print("received event from keyboard \(keyboard) - \(locationId) - \(uniqueId)")
             }
 
-            if conformsToMouse {
+            if !conformsToKbd {
                 if selfPtr.verbosity >= TRACE {
-                    print("ignoring event as device is a mouse")
+                    print("ignoring event as device is not a keyboard")
                 }
                 selfPtr.onKeyboardEvent(keyboard: "CONFORMS_TO_MOUSE")
             } else {


### PR DESCRIPTION
Sooo this might be really dumb, but: I had the same issue as #18 and others before. I looked at the code and the documentation for the function `IOHIDDeviceConformsTo` and figured that some devices might report as both, mouse and keyboard. Those would be discarded.

So I thought, instead of filtering out devices that are (also) mice, why not filter out those that are NOT keyboards?
Is that stupid?

It works great for me with a Logitech ERGO K860 (which is not a mouse but was previously treated as such).

My Apple mouse or the trackpad d not trigger a layout change, so that's ok, too.

Let me know if this works / doesn't work for others, I thought I'd put it out there. I saw the proposals about a config, and that's probably great, too, but I am no Swift dev, so this was all I could contribute :)

Cheers!