### PR TITLE
Add macOS Tahoe (macOS 16) build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-13, macos-14, macos-15, macos-16]
         arch: [arm64, x86_64]
         include:
           - os: macos-13
@@ -20,6 +20,8 @@ jobs:
             os_name: sonoma
           - os: macos-15
             os_name: sequoia
+          - os: macos-16
+            os_name: tahoe
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
             os_name: sonoma
           - os: macos-15
             os_name: sequoia
+          - os: macos-16
+            os_name: tahoe
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
Adds macOS 16 (Tahoe) build support to the repository's CI/CD workflows.

## Changes
- Added `macos-16` runner with OS name `tahoe` to release workflow
- Added `macos-16` runner to test workflow
- Enables building and testing autokbisw on macOS 16 Tahoe for both arm64 and x86_64 architectures

## Release Artifacts
Once merged and tagged, this will generate:
- `autokbisw-{version}.arm64_tahoe.tar.gz`
- `autokbisw-{version}.tahoe.tar.gz`

## Note
macOS 16 runners may not be available on GitHub Actions yet. The workflow will be ready for when GitHub makes these runners available.

## Test plan
- [x] Updated release.yml with macos-16 matrix entry
- [x] Updated test.yml with macos-16 matrix entry
- [ ] Verify workflows run successfully after merge (or handle macos-16 runner unavailability if needed)
